### PR TITLE
Add basic localization setup

### DIFF
--- a/assets/lang/cg.json
+++ b/assets/lang/cg.json
@@ -1,0 +1,10 @@
+{
+  "welcome": "Welcome",
+  "start": "Get Started",
+  "hero_title": "Achieve More with Talented Freelancers",
+  "hero_subtitle": "Devaern brings together businesses and talented freelancers, offering the future of work today.",
+  "why_freelancer": "Why Freelancer?",
+  "popular_services": "Popular Services",
+  "search_title": "What service do you need?",
+  "search_hint": "Software, design, voice over..."
+}

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -1,0 +1,10 @@
+{
+  "welcome": "Welcome",
+  "start": "Get Started",
+  "hero_title": "Achieve More with Talented Freelancers",
+  "hero_subtitle": "Devaern brings together businesses and talented freelancers, offering the future of work today.",
+  "why_freelancer": "Why Freelancer?",
+  "popular_services": "Popular Services",
+  "search_title": "What service do you need?",
+  "search_hint": "Software, design, voice over..."
+}

--- a/assets/lang/tr.json
+++ b/assets/lang/tr.json
@@ -1,0 +1,10 @@
+{
+  "welcome": "Hoş geldiniz",
+  "start": "Hadi Başla",
+  "hero_title": "Yetenekli Freelancerlarla Daha Fazla İş Başarın",
+  "hero_subtitle": "Devaern, özgür çalışan yeteneklerle işletmeleri bir araya getiren, geleceğin çalışma modelini bugünden sunan freelance platformudur.",
+  "why_freelancer": "Neden Freelancer?",
+  "popular_services": "Popüler Hizmetler",
+  "search_title": "Ne hizmete ihtiyacın var?",
+  "search_hint": "Yazılım, tasarım, seslendirme..."
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'screens/home/home_screen.dart'; // Giriş ekranı burası olacak
 
-void main() {
-  runApp(const DevaernApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await EasyLocalization.ensureInitialized();
+  runApp(
+    EasyLocalization(
+      supportedLocales: const [Locale('en'), Locale('tr'), Locale('cg')],
+      path: 'assets/lang',
+      fallbackLocale: const Locale('en'),
+      child: const DevaernApp(),
+    ),
+  );
 }
 
 class DevaernApp extends StatelessWidget {
@@ -13,6 +23,9 @@ class DevaernApp extends StatelessWidget {
     return MaterialApp(
       title: 'Devaern',
       debugShowCheckedModeBanner: false,
+      localizationsDelegates: context.localizationDelegates,
+      supportedLocales: context.supportedLocales,
+      locale: context.locale,
       theme: ThemeData(
         primaryColor: Colors.black,
         scaffoldBackgroundColor: Colors.white,

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:devaern/layout/main_layout.dart'; // Layout'u buradan çekiyoruz
 import 'widgets/hero_section.dart';
 import 'widgets/popular_services.dart';
@@ -11,15 +12,15 @@ class HomeScreen extends StatelessWidget {
     return MainLayout(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: const [
-          HeroSection(),
-          SizedBox(height: 48),
+        children: [
+          const HeroSection(),
+          const SizedBox(height: 48),
           Text(
-            "Popüler Hizmetler",
-            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            'popular_services'.tr(),
+            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
           ),
-          SizedBox(height: 16),
-          PopularServices(),
+          const SizedBox(height: 16),
+          const PopularServices(),
         ],
       ),
     );

--- a/lib/screens/home/widgets/hero_section.dart
+++ b/lib/screens/home/widgets/hero_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import '../../../components/button_primary.dart';
 
 class HeroSection extends StatelessWidget {
@@ -18,25 +19,25 @@ class HeroSection extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                const Text(
-                  "Yetenekli Freelancerlarla Daha Fazla İş Başarın",
-                  style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                Text(
+                  'hero_title'.tr(),
+                  style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 16),
-                const Text(
-                  "Devaern, özgür çalışan yeteneklerle işletmeleri bir araya getiren, geleceğin çalışma modelini bugünden sunan freelance platformudur.",
+                Text(
+                  'hero_subtitle'.tr(),
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 24),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    ButtonPrimary(text: "Hadi Başla", onPressed: () {}),
+                    ButtonPrimary(text: 'start'.tr(), onPressed: () {}),
                     const SizedBox(width: 16),
                     OutlinedButton(
                       onPressed: () {},
-                      child: const Text("Neden Freelancer?"),
+                      child: Text('why_freelancer'.tr()),
                     ),
                   ],
                 ),

--- a/lib/screens/home/widgets/search_banner.dart
+++ b/lib/screens/home/widgets/search_banner.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 
 class SearchBanner extends StatelessWidget {
   const SearchBanner({super.key});
@@ -8,14 +9,14 @@ class SearchBanner extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          "Ne hizmete ihtiyacın var?",
-          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        Text(
+          'search_title'.tr(),
+          style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 12),
         TextField(
           decoration: InputDecoration(
-            hintText: "Yazılım, tasarım, seslendirme...",
+            hintText: 'search_hint'.tr(),
             border: OutlineInputBorder(),
             suffixIcon: Icon(Icons.search),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   lucide_icons: ^0.257.0
+  easy_localization: ^3.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -56,6 +57,9 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+
+  assets:
+    - assets/lang/
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- setup easy_localization package
- add sample translation JSON files
- configure MaterialApp to use EasyLocalization
- update hero and search text to use `.tr()`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418a687250832aa0d81d02766a9ccb