### PR TITLE
Fix test widget and remove duplicate import

### DIFF
--- a/lib/screens/services/widgets/service_card.dart
+++ b/lib/screens/services/widgets/service_card.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import '../../../theme/colors.dart';
 import '../../../theme/text_styles.dart';
 import '../../../theme/buttons.dart';
-import 'package:devaern/theme/text_styles.dart';
 
 class ServiceCard extends StatelessWidget {
   final String title;

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:devaern/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Home screen displays brand name', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const DevaernApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the brand name appears on screen.
+    expect(find.text('Devaern'), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- fix failing widget test by loading `DevaernApp`
- remove duplicate import from `ServiceCard`

## Testing
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68418a36d7d4832abebc5d8b5efd71e0